### PR TITLE
Added support for passing in pandas dataframe as an input to pfa

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pfa(path*, number_output_functions, number_sweeps, cluster_size, alpha, min_n_da
 ```
 
 ### Parameters
-- **path (String, required):** Path to the input CSV file.
+- **path (String or pandas DataFrame, required):** Path to the input CSV file or pandas dataframe.
 - **number_output_functions (int, default=1):** Number of output features that are to be modeled, i.e. the number of components of the vector-valued output-function. The values are stored in the first number_output_functions rows of the csv-file.
 - **number_sweeps (int, default=1):** Number of sweeps of the PFA. The result of the last sweep is returned. In addition, the return of each sweep are interesected and returned as well.
 - **cluster_size (int, default=50):** Number of nodes of a subgraph in the principal_feature_analysis.

--- a/src/principal_feature_analysis/execute_PFA.py
+++ b/src/principal_feature_analysis/execute_PFA.py
@@ -31,8 +31,15 @@ def pfa(path, number_output_functions=1, number_sweeps=1, cluster_size=50, alpha
 
     # The csv file's content is an m x n Matrix with m - number components of output-function = number features and n = number of data points
     # where the first number components of output-function rows contain the value of the vector-valued output function for each of the n data points
-    # e.g. in case of a one-dimensional output function, the first row can be the label for each data point
-    data = pd.read_csv(path, sep=',', header=None)
+    # e.g. in case of a one-dimensional output function, the first row can be the label for each data point.
+    # Instead of a CSV file you can also pass a pandas dataframe.
+    if isinstance(path, str):
+        data = pd.read_csv(path, sep=',', header=None)
+    elif isinstance(path, pd.DataFrame):
+        data = path
+    else:
+        raise NotImplementedError(f"path type {type(path)} has not been implemented")
+
     for sweep in range(0,number_sweeps):
         print("Sweep number: " + str(sweep+1))
         pf_ds,pf,indices_principal_feature_values=find_relevant_principal_features(data,number_output_functions,cluster_size,alpha,min_n_datapoints_a_bin,shuffle_feature_numbers,frac)


### PR DESCRIPTION
Thanks for the great piece of software!

My use case might be niche so feel free to reject this but I found it would be helpful if I directly pass the pandas dataframe to the `pfa` function rather than saving results as a csv file and then passing the csv path.